### PR TITLE
Update 90_utils.js

### DIFF
--- a/bits/90_utils.js
+++ b/bits/90_utils.js
@@ -68,6 +68,7 @@ function format_cell(cell, v) {
 function sheet_to_json(sheet, opts){
 	var val, row, range, header = 0, offset = 1, r, hdr = [], isempty, R, C, v;
 	var o = opts != null ? opts : {};
+
 	var raw = o.raw;
 	if(sheet == null || sheet["!ref"] == null) return [];
 	range = o.range !== undefined ? o.range : sheet["!ref"];
@@ -87,6 +88,7 @@ function sheet_to_json(sheet, opts){
 	for(C = r.s.c; C <= r.e.c; ++C) {
 		cols[C] = encode_col(C);
 		val = sheet[cols[C] + rr];
+
 		switch(header) {
 			case 1: hdr[C] = C; break;
 			case 2: hdr[C] = cols[C]; break;
@@ -108,20 +110,32 @@ function sheet_to_json(sheet, opts){
 		}
 		for (C = r.s.c; C <= r.e.c; ++C) {
 			val = sheet[cols[C] + rr];
-			if(val === undefined || val.t === undefined) continue;
-			v = val.v;
-			switch(val.t){
-				case 'e': continue;
-				case 's': break;
-				case 'b': case 'n': break;
-				default: throw 'unrecognized type ' + val.t;
+
+			if(val === undefined || val.t === undefined) {
+				if (o.parseEmpty && hdr[C]) {
+					val = null;
+					v = '';
+				}
+				else continue;
+			}
+			else {
+				v = val.v;
+				switch(val.t){
+					case 'e': continue;
+					case 's': break;
+					case 'b': case 'n': break;
+					default: throw 'unrecognized type ' + val.t;
+				}
 			}
 			if(v !== undefined) {
 				row[hdr[C]] = raw ? v : format_cell(val,v);
-				isempty = false;
+				if (v) isempty = false;
 			}
 		}
-		if(isempty === false || header === 1) out[outi++] = row;
+		if(isempty === false || header === 1) {
+			out[outi++] = row;
+		}
+			
 	}
 	out.length = outi;
 	return out;


### PR DESCRIPTION
Proposed solution to Issue 147 (where a column in which the first row is an empty cell is dropped, even if later rows in the column are non-empty). 

Allow user to pass in parameter parseEmpty: true (or something truthy). 

In sheet_to_json, this will create a val of '' where a cell is empty, rather than going straight to continue. To guard against empty rows being added, isEmpty is still not set to true unless the val is truthy. 